### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,11 @@ Running SARAH is fast, it already includes a long list of SUSY and non-SUSY mode
 
 https://sarah.hepforge.org/
 
-***
+### TOP++
+
+Purpose: The TOP++ program calculates the total inclusive cross-section for top-pair production at hadron colliders like the Tevatron and LHC. The program is capable of calculating the cross-section in fixed order QCD with exact NNLO. The program can also perform full NNLL soft gluon resummation. The resummation is done in Mellin space and then inverted numerically to x-space via the so-called Minimal Prescription.
+
+http://www.precision.hep.phy.cam.ac.uk/top-plus-plus/
 
 ## Direct Detection
 


### PR DESCRIPTION
added TOP++, for higher order QCD calculations of 3rd gen quark production (also used a lot in BSM models for cross section calculations for vector-like quarks for example). Was unsure to add in "spectrum" or in "generator category", but because TOP++ does not really generate events I figured it fits better in the former.