### PR TITLE
Added pynkowski

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,12 @@ https://bdiemer.bitbucket.io/colossus/
 
 [https://github.com/valerio-marra/CalPriorSNIa](https://github.com/valerio-marra/CalPriorSNIa)
 
+### Pynkowski
+
+[Pynkowski](https://github.com/javicarron/pynkowski) is a fully documented Python package to compute Minkowki Functional and other higher order statistics of input fields, as well as computing the expectation values for different kinds of fields. It can compute these statistics on different kinds of data, such as healpix maps (scalar and spin 2) and two- and three-dimensional numpy arrays. It can also compute the theoretical expectation for different fields, including Gaussian and $\chi^2$ isotropic fields. It includes Minkowski Functionals (also called Lipschitz-Killing Curvatures) and maxima/minima distributions. The code has been designed to easily support more data formats, theoretical fields, and statistics.
+
+https://github.com/javicarron/pynkowski (Documentation [here](https://javicarron.github.io/pynkowski/pynkowski.html))
+
 ***
 
 ## Inflationary Cosmology


### PR DESCRIPTION
I added pynkowski (https://github.com/javicarron/pynkowski) to the list. I added it to "General Cosmology" topic, but there is an argument to be made for a minor change.

This is a package to compute different kinds of statistics on fields (mostly Minkowski Functionals and maxima/minima distribution so far), so it has a very similar purpose to the codes in "Correlation Function Estimation". The only difference is that, instead of computing n-order correlation functions, it computes other kinds of statistics (higher-order statistics). I would propose to change the name of the topic from "Correlation Function Estimation" to something like "Statistics Estimation" or "Statistical Descriptors Estimation" or something like that (maybe also "Correlation Function and Higher-order Statistics").

Otherwise, I'm happy to keep it in the General Cosmology topic, as you prefer.

Thanks for maintaining this repository, it's great!